### PR TITLE
Display commit hash in kernel version string

### DIFF
--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -5,6 +5,7 @@ ARG KERNEL_BIN=arch/x86/boot/bzImage
 # set from a Makefile.eve
 ARG SOURCE_DATE_EPOCH
 ARG KBUILD_BUILD_TIMESTAMP
+ARG LOCALVERSION
 
 FROM --platform=${BUILDPLATFORM} alpine:${ALPINE_VERSION} as builder-native-base
 RUN apk add make flex bison elfutils-dev openssl-dev findutils diffutils perl ccache gcc libgcc musl-dev \
@@ -75,6 +76,7 @@ ARG SOURCE_DATE_EPOCH
 ARG KBUILD_BUILD_TIMESTAMP
 ARG KERNEL_CONFIG
 ARG KERNEL_BIN
+ARG LOCALVERSION
 # ARCH and CROSS_COMPILE are inherited from builder-${TARGETARCH}-${BUILDARCH}
 # ARCH is always set to the target arch
 # CROSS_COMPILE is set to empty string for native builds
@@ -95,12 +97,12 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=kernel-ccache-${TARGETARCH}
     echo "Building kernel for ${TARGETARCH} with ARCH=${ARCH} and CROSS_COMPILE=${CROSS_COMPILE}" && \
     make -j$(nproc) mrproper \
     && make O=/kernel-out ${KERNEL_CONFIG} \
-    && make O=/kernel-out -j$(nproc) prepare \
-    && make O=/kernel-out -j$(nproc) \
-    && make O=/kernel-out -j$(nproc) modules \
-    && make O=/kernel-out -j$(nproc) modules_install INSTALL_MOD_STRIP=1 \
-        INSTALL_MOD_PATH=/tmp/kernel-modules && \
-    ccache -s
+    && make O=/kernel-out LOCALVERSION="-${LOCALVERSION}" -j$(nproc) prepare \
+    && make O=/kernel-out LOCALVERSION="-${LOCALVERSION}" -j$(nproc) \
+    && make O=/kernel-out LOCALVERSION="-${LOCALVERSION}" -j$(nproc) modules \
+    && make O=/kernel-out LOCALVERSION="-${LOCALVERSION}" -j$(nproc) modules_install INSTALL_MOD_STRIP=1 \
+        INSTALL_MOD_PATH=/tmp/kernel-modules \
+    && ccache -s
 
 ADD https://github.com/mikem-zed/zfs.git#eve-zfs-2.1.12 /tmp/zfs
 WORKDIR /tmp/zfs

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -35,6 +35,7 @@ kernel-%: Dockerfile.%
 	docker buildx build \
 	--build-arg="SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)" \
 	--build-arg="KBUILD_BUILD_TIMESTAMP=$(KBUILD_BUILD_TIMESTAMP)" \
+	--build-arg="LOCALVERSION=$(VERSION)$(DIRTY)" \
 	--platform $(PLATFORM) -t lfedge/eve-kernel:$(BRANCH)-$(VERSION)$(DIRTY)-$* --load -f Dockerfile.$* .
 
 docker-tag-%:

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -1,5 +1,5 @@
 # Title: Dockerfile for building the EVE kernel
-VERSION=$(shell git rev-parse --short HEAD)
+VERSION=$(shell git rev-parse --short=12 HEAD)
 DIRTY=$(shell git diff --quiet || echo '-dirty')
 EVE_FLAVOR=generic
 ARCHITECTURE=amd64


### PR DESCRIPTION
- set hash length to 12 digits
- now kernel version is displayed like this "6.1.38-linuxkit-deadbeef1234-dirty"
- docker tags also 12 digits long