### PR TITLE
[Merge PR into eve-kernel-arm64-v6.1.38-generic] Override ACS capability even if it is supported by device 

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -267,9 +267,8 @@ static int pcie_acs_overrides(struct pci_dev *dev, u16 acs_flags)
 {
 	int i;
 
-	/* Never override ACS for legacy devices or devices with ACS caps */
-	if (!pci_is_pcie(dev) ||
-		pci_find_ext_capability(dev, PCI_EXT_CAP_ID_ACS))
+	/* Never override ACS for legacy devices */
+	if (!pci_is_pcie(dev))
 			return -ENOTTY;
 
 	for (i = 0; i < max_acs_id; i++)
@@ -277,18 +276,18 @@ static int pcie_acs_overrides(struct pci_dev *dev, u16 acs_flags)
 			acs_on_ids[i].device == dev->device)
 				return 1;
 
-switch (pci_pcie_type(dev)) {
-	case PCI_EXP_TYPE_DOWNSTREAM:
-	case PCI_EXP_TYPE_ROOT_PORT:
-		if (acs_on_downstream)
-			return 1;
-		break;
-	case PCI_EXP_TYPE_ENDPOINT:
-	case PCI_EXP_TYPE_UPSTREAM:
-	case PCI_EXP_TYPE_LEG_END:
-	case PCI_EXP_TYPE_RC_END:
-		if (acs_on_multifunction && dev->multifunction)
-			return 1;
+	switch (pci_pcie_type(dev)) {
+		case PCI_EXP_TYPE_DOWNSTREAM:
+		case PCI_EXP_TYPE_ROOT_PORT:
+			if (acs_on_downstream)
+				return 1;
+			break;
+		case PCI_EXP_TYPE_ENDPOINT:
+		case PCI_EXP_TYPE_UPSTREAM:
+		case PCI_EXP_TYPE_LEG_END:
+		case PCI_EXP_TYPE_RC_END:
+			if (acs_on_multifunction && dev->multifunction)
+				return 1;
 	}
 
 	return -ENOTTY;


### PR DESCRIPTION
Merge PR https://github.com/lf-edge/eve-kernel/pull/11 into eve-kernel-arm64-v6.1.38-generic