### PR TITLE
docker login only in case of branch build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   packages:
     runs-on: self-hosted
-    if: ${{ github.event.review.state == 'approved' || github.ref == 'refs/heads/eve-kernel-amd64-v6.1.38-generic' }}
+    if: ${{ github.event.review.state == 'approved' }} || github.ref == env.branch_name
     steps:
       - name: Get eve-kernel
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
           make -f Makefile.eve BRANCH?=${GITHUB_REF##*/} kernel-gcc
 
       - name: Log in to Docker Hub
+        if: github.ref == 'refs/heads/eve-kernel-amd64-v6.1.38-generic'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - "eve-kernel-amd64-v6.1.38-generic"
+env:
+  branch_name: "refs/heads/eve-kernel-amd64-v6.1.38-generic"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,13 +29,13 @@ jobs:
           make -f Makefile.eve BRANCH?=${GITHUB_REF##*/} kernel-gcc
 
       - name: Log in to Docker Hub
-        if: github.ref == 'refs/heads/eve-kernel-amd64-v6.1.38-generic'
+        if: ${{ github.ref == env.branch_name }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
           password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
       
       - name: Push eve-kernel-amd64-v6.1.38-generic if PR approved or pushed
-        if: github.ref == 'refs/heads/eve-kernel-amd64-v6.1.38-generic'
+        if: ${{ github.ref == env.branch_name }}
         run: |
           make -f Makefile.eve BRANCH?=${GITHUB_REF##*/} push-gcc


### PR DESCRIPTION
To login to dockerhub only in case of branch build. The login is needed to push the tag to remote.