### PR TITLE
Update to OpenZFS 2.2.2

### DIFF
--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=kernel-ccache-${TARGETARCH}
         INSTALL_MOD_PATH=/tmp/kernel-modules \
     && ccache -s
 
-ADD https://github.com/mikem-zed/zfs.git#eve-zfs-2.1.12 /tmp/zfs
+ADD https://github.com/openzfs/zfs.git#zfs-2.2.2 /tmp/zfs
 WORKDIR /tmp/zfs
 
 RUN --mount=type=cache,target=/root/.cache/ccache,id=zfs-ccache-${TARGETARCH} \


### PR DESCRIPTION
Upstream contains the patches we were using
in the mikem-zed fork.  Syncing up with upstream
will provide us with many upstream fixes and a few new ZFS features including performance improvements.

Paired with this PR will be a matching PR on the lf-edge/eve side to update the user libzfs which requires a kernel commit id and docker tag created after this PR merges.