### PR TITLE
Generate SBOM using buildkit's builtin mechanism

### DIFF
--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -169,10 +169,6 @@ RUN DVER=$(basename $(find /tmp/kernel-modules/lib/modules/ -mindepth 1 -maxdept
          tar cf - -T - | (cd $dir; tar xf -) && \
     ( cd /tmp && tar cf /out/kernel-dev.tar usr/src )
 
-# copy SBOM files
-RUN cp /kernel-src/kernel-sbom-docker.spdx.json /out/ && \
-    cp /kernel-src/kernel-sbom-gh.spdx.json /out/
-
 FROM scratch
 ENTRYPOINT []
 CMD []

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -7,6 +7,12 @@ KERNEL_TAG=v6.1.38
 PLATFORM=linux/$(ARCHITECTURE)
 BUILD_USER:=$(shell id -un)
 
+IMAGE_REPOSITORY?=lfedge/eve-kernel
+
+LINUXKIT_VERSION=58c36c9eb0c32acf66ae7877d18a9ad24d59d73e
+GOBIN=/tmp/linuxkit-$(LINUXKIT_VERSION)
+LK=$(GOBIN)/linuxkit
+
 SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct)
 BRANCH=eve-kernel-$(ARCHITECTURE)-$(KERNEL_TAG)-$(EVE_FLAVOR)
 # make sure we get a date in correct format, otherwise initramfs cpio mtime will be variable
@@ -41,20 +47,24 @@ help: Makefile
 	@echo "  clean: remove generated files"
 	@echo
 
-pull-eve-build-tools:
-	docker pull lfedge/eve-build-tools:main
-.PHONY: pull-eve-build-tools
+.PHONY: linuxkit
+linuxkit: $(LK)
+$(LK):
+	GOBIN=$(GOBIN) go install github.com/linuxkit/linuxkit/src/cmd/linuxkit@$(LINUXKIT_VERSION)
 
-kernel-gcc: DOCKERFILE:=Dockerfile.gcc
-kernel-clang: DOCKERFILE:=Dockerfile.clang
+KERNEL_OCI_FILE:=$(shell mktemp -u)-kernel.tar
 
-kernel-build-%: Makefile.eve
+kernel-build-%: Makefile.eve linuxkit
 	@echo "Building kernel version $(BRANCH):$(VERSION)-$* with compiler $*"
 	docker buildx build \
 	--build-arg="SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)" \
 	--build-arg="KBUILD_BUILD_TIMESTAMP=$(KBUILD_BUILD_TIMESTAMP)" \
 	--build-arg="LOCALVERSION=$(VERSION)$(DIRTY)" \
-	--platform $(PLATFORM) -t lfedge/eve-kernel:$(BRANCH)-$(VERSION)$(DIRTY)-$* --load -f Dockerfile.$* .
+	--platform $(PLATFORM) -t $(IMAGE_REPOSITORY):$(BRANCH)-$(VERSION)$(DIRTY)-$* \
+	--sbom=true --output=type=oci,dest=$(KERNEL_OCI_FILE) -f Dockerfile.$* .
+	$(LK) cache import $(KERNEL_OCI_FILE)
+	rm -f $(KERNEL_OCI_FILE)
+
 
 # we need these intermediate targets to make .PHONY work for pattern rules
 kernel-gcc: kernel-build-gcc
@@ -67,11 +77,11 @@ push-clang: push-image-clang
 .PHONY: kernel-gcc kernel-clang docker-tag-gcc docker-tag-clang push-gcc push-clang
 
 docker-tag-generate-%:
-	@echo "docker.io/lfedge/eve-kernel:$(BRANCH)-$(VERSION)$(DIRTY)-$*"
+	@echo "docker.io/$(IMAGE_REPOSITORY):$(BRANCH)-$(VERSION)$(DIRTY)-$*"
 
 push-image-%:
 	$(if $(DIRTY), $(error "Not pushing since the repo is dirty"))
-	docker push lfedge/eve-kernel:$(BRANCH)-$(VERSION)-$*
+	$(LK) cache push $(IMAGE_REPOSITORY):$(BRANCH)-$(VERSION)-$*
 
 .PHONY: clean
 clean:

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -45,28 +45,10 @@ pull-eve-build-tools:
 	docker pull lfedge/eve-build-tools:main
 .PHONY: pull-eve-build-tools
 
-# do not build sbom target directly, it depends on DOCKERFILE variable set by kernel-gcc or kernel-clang
-SBOM_TARGETS=kernel-sbom-gh.spdx.json kernel-sbom-docker.spdx.json
-sbom: $(SBOM_TARGETS)
-
-kernel-sbom-gh.spdx.json: pull-eve-build-tools
-	docker run  -v $(PWD):/in lfedge/eve-build-tools:main github-sbom-generator \
-			generate --format spdx-json /in/ | jq . > ./kernel-sbom-gh.spdx.json
-
-#if DOCKERFILE is not set, this target will fail
-kernel-sbom-docker.spdx.json: pull-eve-build-tools $(DOCKERFILE)
-	@if [ -z "$(DOCKERFILE)" ]; then \
-		echo "DOCKERFILE not set. Do not build 'sbom' target directly"; \
-		exit 1; \
-	fi
-	@echo "Generating SBOM for $(DOCKERFILE)"
-	docker run -v $(PWD):/in lfedge/eve-build-tools:main dockerfile-add-scanner scan /in/$(DOCKERFILE) \
-		--format spdx-json | jq . > ./kernel-sbom-docker.spdx.json
-
 kernel-gcc: DOCKERFILE:=Dockerfile.gcc
 kernel-clang: DOCKERFILE:=Dockerfile.clang
 
-kernel-build-%: sbom Makefile.eve
+kernel-build-%: Makefile.eve
 	@echo "Building kernel version $(BRANCH):$(VERSION)-$* with compiler $*"
 	docker buildx build \
 	--build-arg="SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)" \
@@ -93,4 +75,4 @@ push-image-%:
 
 .PHONY: clean
 clean:
-	rm -f $(SBOM_TARGETS)
+	echo "Cleaning"

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -13,6 +13,9 @@ LINUXKIT_VERSION=58c36c9eb0c32acf66ae7877d18a9ad24d59d73e
 GOBIN=/tmp/linuxkit-$(LINUXKIT_VERSION)
 LK=$(GOBIN)/linuxkit
 
+BUILD_KIT_VERSION=v0.12.5
+BUILD_KIT_BUILDER=eve-kernel-builder-$(BUILD_KIT_VERSION)
+
 SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct)
 BRANCH=eve-kernel-$(ARCHITECTURE)-$(KERNEL_TAG)-$(EVE_FLAVOR)
 # make sure we get a date in correct format, otherwise initramfs cpio mtime will be variable
@@ -47,6 +50,12 @@ help: Makefile
 	@echo "  clean: remove generated files"
 	@echo
 
+.PHONY: ensure-builder
+ensure-builder:
+	docker buildx inspect $(BUILD_KIT_BUILDER) 2>/dev/null || \
+	docker buildx create --name $(BUILD_KIT_BUILDER) \
+	--driver docker-container --bootstrap --driver-opt=image=moby/buildkit:$(BUILD_KIT_VERSION)
+
 .PHONY: linuxkit
 linuxkit: $(LK)
 $(LK):
@@ -54,9 +63,10 @@ $(LK):
 
 KERNEL_OCI_FILE:=$(shell mktemp -u)-kernel.tar
 
-kernel-build-%: Makefile.eve linuxkit
+kernel-build-%: Makefile.eve linuxkit | ensure-builder
 	@echo "Building kernel version $(BRANCH):$(VERSION)-$* with compiler $*"
 	docker buildx build \
+	--builder=$(BUILD_KIT_BUILDER) \
 	--build-arg="SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)" \
 	--build-arg="KBUILD_BUILD_TIMESTAMP=$(KBUILD_BUILD_TIMESTAMP)" \
 	--build-arg="LOCALVERSION=$(VERSION)$(DIRTY)" \


### PR DESCRIPTION
- [x] `linuxkit cache push` is not implemented yet see https://github.com/linuxkit/linuxkit/issues/3990
- [x] tested on a local eve build
- [x] `linuxkit cache push` requires one tiny fix to avoid extra image tag creation https://github.com/linuxkit/linuxkit/issues/3996

This PR should address https://github.com/lf-edge/eve-kernel/issues/50