### PR TITLE
[RT] sched/isolation: add 'inverse' parameter for the 'nohz_full' and 'isolcpus'

### DIFF
--- a/kernel/sched/isolation.c
+++ b/kernel/sched/isolation.c
@@ -106,7 +106,7 @@ static void __init housekeeping_setup_type(enum hk_type type,
 		     housekeeping_staging);
 }
 
-static int __init housekeeping_setup(char *str, unsigned long flags)
+static int __init housekeeping_setup(char *str, unsigned long flags, bool inverse)
 {
 	cpumask_var_t non_housekeeping_mask, housekeeping_staging;
 	int err = 0;
@@ -124,6 +124,8 @@ static int __init housekeeping_setup(char *str, unsigned long flags)
 		pr_warn("Housekeeping: nohz_full= or isolcpus= incorrect CPU range\n");
 		goto free_non_housekeeping_mask;
 	}
+	if (inverse)
+		cpumask_complement(non_housekeeping_mask, non_housekeeping_mask);
 
 	alloc_bootmem_cpumask_var(&housekeeping_staging);
 	cpumask_andnot(housekeeping_staging,
@@ -180,11 +182,40 @@ free_non_housekeeping_mask:
 static int __init housekeeping_nohz_full_setup(char *str)
 {
 	unsigned long flags;
+	bool illegal = false;
+	bool inverse = false;
+	char *par;
+	int len;
+
+	while (isalpha(*str)) {
+		if (!strncmp(str, "inverse,", 8)) {
+			str += 8;
+			inverse = true;
+			continue;
+		}
+
+		/*
+		 * Skip unknown sub-parameter and validate that it is not
+		 * containing an invalid character.
+		 */
+		for (par = str, len = 0; *str && *str != ','; str++, len++) {
+			if (!isalpha(*str) && *str != '_')
+				illegal = true;
+		}
+
+		if (illegal) {
+			pr_warn("nohz_full: Invalid flag %.*s\n", len, par);
+			return 0;
+		}
+
+		pr_info("nohz_full: Skipped unknown flag %.*s\n", len, par);
+		str++;
+	}
 
 	flags = HK_FLAG_TICK | HK_FLAG_WQ | HK_FLAG_TIMER | HK_FLAG_RCU |
 		HK_FLAG_MISC | HK_FLAG_KTHREAD;
 
-	return housekeeping_setup(str, flags);
+	return housekeeping_setup(str, flags, inverse);
 }
 __setup("nohz_full=", housekeeping_nohz_full_setup);
 
@@ -192,6 +223,7 @@ static int __init housekeeping_isolcpus_setup(char *str)
 {
 	unsigned long flags = 0;
 	bool illegal = false;
+	bool inverse = false;
 	char *par;
 	int len;
 
@@ -211,6 +243,12 @@ static int __init housekeeping_isolcpus_setup(char *str)
 		if (!strncmp(str, "managed_irq,", 12)) {
 			str += 12;
 			flags |= HK_FLAG_MANAGED_IRQ;
+			continue;
+		}
+
+		if (!strncmp(str, "inverse,", 8)) {
+			str += 8;
+			inverse = true;
 			continue;
 		}
 
@@ -236,6 +274,6 @@ static int __init housekeeping_isolcpus_setup(char *str)
 	if (!flags)
 		flags |= HK_FLAG_DOMAIN;
 
-	return housekeeping_setup(str, flags);
+	return housekeeping_setup(str, flags, inverse);
 }
 __setup("isolcpus=", housekeeping_isolcpus_setup);


### PR DESCRIPTION
By default 'nohz_full' and 'isolcpus' accept a range of those CPUs,  which should be isolated from the housekeeping, with 'inverse' the logic is inverted: you specify CPUs for housekeeping tasks, others are isolated.
    
The motivation of the patch is to generalize and simplify kernel configuration, when maximum number of CPUs is not always known (or is not convenient to change the grub config each time hardware changes), but what is known is that CPU0 will do the whole housekeeping, so the command line becomes:
    
        isolcpus=inverse,0 nohz_full=inverse,0
    
instead of
    
       isolcpus=1-N nohz_full=1-N
    
where N is the index of the maximum CPU, which can't be always known.
