### PR TITLE
Dockerfile.gcc: Change rtw88 revision

### DIFF
--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -142,7 +142,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=zfs-ccache-${TARGETARCH} \
     ccache -s
 
 # rtw88 wireless driver
-ENV RTW88_REVISION=master
+ENV RTW88_REVISION="22/4/24"
 ADD https://github.com/lwfinger/rtw88.git#${RTW88_REVISION} /tmp/rtw88
 WORKDIR /tmp/rtw88
 


### PR DESCRIPTION
Update rtw88 to a tagged revision which is known to build successfully with our kernel.

~~The current rtw88 WiFi driver repository doesn't have any tags or branches fixed to the revision used by EVE and the current master branch is broken (doesn't build with eve-kernel). This commit moves the rtw88 to an alternative repository, with the right revision tagged.~~