### PR TITLE
stmmac: Do not enable/disable runtime PM for PCI devices

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -7299,7 +7299,9 @@ int stmmac_dvr_probe(struct device *device,
 
 	pm_runtime_get_noresume(device);
 	pm_runtime_set_active(device);
-	if (!pm_runtime_enabled(device))
+
+	/* For PCI devices PM is disabled/enabled by the framework */
+	if (!priv->plat->pdev)
 		pm_runtime_enable(device);
 
 	if (priv->hw->pcs != STMMAC_PCS_TBI &&
@@ -7408,7 +7410,10 @@ int stmmac_dvr_remove(struct device *dev)
 	mutex_destroy(&priv->lock);
 	bitmap_free(priv->af_xdp_zc_qps);
 
-	pm_runtime_disable(dev);
+	/* For PCI devices PM is disabled/enabled by the framework */
+	if (!priv->plat->pdev)
+		pm_runtime_disable(dev);
+
 	pm_runtime_put_noidle(dev);
 
 	return 0;


### PR DESCRIPTION
Common function stmmac_dvr_probe is called for both PCI and non-PCI device. For PCI devices pm_runtime_enable/disable are called by framework and should not be called by the driver.

For PCI devices plat->pdev != NULL. Use this fact to detect PCI devices

**EDIT**: the detailed explanation is here https://lore.kernel.org/kvm/23maxefvqgcelvlpckq6jmnzqeo5e3j7ku2pquykwvupgzyl6k@f6tt4wtzsxnj/T/
