### PR TITLE
Dockerfile: add pahole dependency

### DIFF
--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -24,6 +24,7 @@ RUN apk add --no-cache \
     bash \
     findutils \
     diffutils \
+    pahole \
     perl \
     ccache \
     # for ZFS

--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -15,6 +15,7 @@ RUN apk add make flex bison elfutils-dev openssl-dev findutils diffutils perl cc
     util-linux-dev \
     libtirpc-dev \
     libaio-dev \
+    pahole \
     python3 \
     openssl \
     linux-headers \


### PR DESCRIPTION
pahole is used during the compile time of the linux kernel to extract debug information and make it available via sysfs