### PR TITLE
Introduces support for Siemens IPC520A

### DIFF
--- a/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile
+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/Makefile
@@ -14,6 +14,7 @@ dtb-$(BUILD_ENABLE) += tegra194-p3668-0000-p3509-0000.dtb
 dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000.dtb
 dtb-$(BUILD_ENABLE) += tegra194-p3668-0001-p3509-0000-lenovo-se70.dtb
 dtb-$(CONFIG_ARCH_TEGRA_19x_SOC) += tegra194-p3668-all-p3509-0000-kexec.dtb
+dtb-$(BUILD_ENABLE) += tegra194-siemens-ipc520a.dtb
 dtbo-$(BUILD_ENABLE) += tegra194-p3668-all-p3509-0000-hdr40.dtbo
 dtbo-$(BUILD_ENABLE) += tegra194-p3668-all-p3509-0000-adafruit-sph0645lm4h.dtbo
 dtbo-$(BUILD_ENABLE) += tegra194-p3668-all-p3509-0000-adafruit-uda1334a.dtbo

--- a/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-siemens-ipc520a.dtsi
+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-siemens-ipc520a.dtsi
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Siemens AG, 2023
+ *
+ * Authors:
+ *  Nian Gao <nian.gao@siemens.com>
+ */
+
+/ {
+	leds {
+		compatible = "gpio-leds";
+		status = "okay";
+
+		user-led-red {
+			gpios = <&pcal9535 14 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "gpio";
+			default-state = "off";
+		};
+
+		user-led-green {
+			gpios = <&pcal9535 15 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "gpio";
+			default-state = "off";
+		};
+
+		/delete-node/ pwr;
+	};
+
+	gpio@2200000 {
+		DI_0 {
+			gpio-hog;
+			input;
+			gpios = <TEGRA194_MAIN_GPIO(Q, 5) GPIO_ACTIVE_LOW>;
+			label = "DI_0";
+			status = "okay";
+		};
+
+		DI_1 {
+			gpio-hog;
+			input;
+			gpios = <TEGRA194_MAIN_GPIO(Q, 3) GPIO_ACTIVE_LOW>;
+			label = "DI_1";
+			status = "okay";
+		};
+
+		WWAN_RST_N {
+			gpio-hog;
+			output-high;
+			gpios = <TEGRA194_MAIN_GPIO(P, 0) GPIO_ACTIVE_HIGH>;
+			label = "WWAN_RST_N";
+			status = "okay";
+		};
+	};
+
+	gpio@c2f0000 {
+		DI_2 {
+			gpio-hog;
+			input;
+			gpios = <TEGRA194_AON_GPIO(CC, 0) GPIO_ACTIVE_LOW>;
+			label = "DI_2";
+			status = "okay";
+		};
+
+		DI_3 {
+			gpio-hog;
+			input;
+			gpios = <TEGRA194_AON_GPIO(CC, 1) GPIO_ACTIVE_LOW>;
+			label = "DI_3";
+			status = "okay";
+		};
+
+		DO_0 {
+			gpio-hog;
+			output-low;
+			gpios = <TEGRA194_AON_GPIO(CC, 2) GPIO_ACTIVE_HIGH>;
+			label = "DO_0";
+			status = "okay";
+		};
+
+		DO_1 {
+			gpio-hog;
+			output-low;
+			gpios = <TEGRA194_AON_GPIO(CC, 3) GPIO_ACTIVE_HIGH>;
+			label = "DO_1";
+			status = "okay";
+		};
+
+		/delete-node/ w-disable1;
+
+		/delete-node/ w-disable2;
+
+		/delete-node/ suspend-led-gpio;
+	};
+
+	cam_i2cmux {
+		/delete-property/ mux-gpios;
+	};
+
+	pinmux@2430000 {
+		pinctrl-names = "default";
+		pinctrl-0 = <&jetson_io_pinmux>;
+
+		jetson_io_pinmux: exp-header-pinmux {
+			hdr40-pin11 {
+				nvidia,lpdr = <0x0>;
+				nvidia,enable-input = <0x0>;
+				nvidia,tristate = <0x0>;
+				nvidia,pull = <0x0>;
+				nvidia,function = "uarta";
+				nvidia,pins = "uart1_rts_pr4";
+			};
+
+			hdr40-pin36 {
+				nvidia,pins = "uart1_cts_pr5";
+				nvidia,function = "uarta";
+				nvidia,pin-group = "uarta-cts/rts";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+				nvidia,lpdr = <TEGRA_PIN_DISABLE>;
+			};
+		};
+	};
+
+	/* not battery-backed */
+	rtc@c2a0000 {
+		status = "disabled";
+	};
+
+};
+
+&sdmmc3 {
+	nvidia,sd-device;
+	cd-gpios = <&tegra_main_gpio TEGRA194_MAIN_GPIO(S, 4) 0>;
+	power-gpios = <&tegra_aon_gpio TEGRA194_AON_GPIO(AA, 2) GPIO_ACTIVE_HIGH>;  // details of GPIO port used to power up SDIO card, Specify GPIOs for power control
+	mmc-ocr-mask = <0>; // Specify OCR register masking details. Based on this value the power up voltage depending on board capabilities can be selected.
+	status = "okay";
+	/delete-property/ nvidia,vqmmc-always-on; // we have SDMMC_VDD_EN gpio
+	/delete-property/ cd-inverted;  // invert the value of external card detect gpio line
+};
+
+&gen2_i2c {
+	pinctrl-names = "default";
+	clock-frequency = <400000>;
+	status = "okay";
+
+	eeprom: eeprom@54 {
+		compatible = "24c08";
+		reg = <0x54>;
+		pagesize = <16>;
+	};
+
+	pcal9535: gpio@23 {
+		compatible = "nxp,pca9535";
+		reg = <0x23>;
+		#gpio-cells = <2>;
+		/* must use 'vcc-supply' for devm_regulator_get() in driver gpio-pca953x.c */
+		vcc-supply = <&p3509_vdd_3v3_cvb>;
+		gpio-controller;
+		gpio-line-names = "BAT_CHECK_EN", "BAT_PRESENT_N", "BAT_LOW_N", "BAT_FAIL_N",
+							"DISABLE_WIFI_N", "DISABLE_BT_N",
+							"NC",
+							"WWAN_PWR_OFF_N", "WWAN_DISABLE_N",
+							"COM1_EN", "COM1_MODE0", "COM1_MODE1", "COM1_RTS_N", "COM1_TERM",
+							"LED_UDF_RD", "LED_UDF_GN";
+
+		wifi-disable {
+			gpio-hog;
+			output-high;
+			gpios = <4 0>;
+			label = "wifi-disable";
+			status = "okay";
+		};
+
+		bt-disable {
+			gpio-hog;
+			output-high;
+			gpios = <5 0>;
+			label = "bt-disable";
+			status = "okay";
+		};
+
+		wwan_pwr_off {
+			gpio-hog;
+			output-high;
+			gpios = <7 0>;
+			label = "wwan_pwr_off";
+			status = "okay";
+		};
+
+		wwan_disable {
+			gpio-hog;
+			output-high;
+			gpios = <8 0>;
+			label = "wwan_disable";
+			status = "okay";
+		};
+	};
+
+	tps23861@20 {
+		compatible = "ti,tps23861";
+		reg = <0x20>;
+		sense-resistor = <250000>;	/* micro-ohms */
+		irq-gpio = <&tegra_main_gpio TEGRA194_MAIN_GPIO(N, 1) 0>;
+
+		dynamic-power;			/* you must set max-power and power-volt if dynamic-power */
+		max-power = <31968>;	/* mW */
+		power-volt = <54000>;	/* mV */
+
+		port0 {
+			label = "poe_1";
+			mode = "semiauto";		/* manual | semiauto | auto */
+			max-power = <20196>;	/* mW, you must set max-power if in mannual or semiauto mode */
+			auto-power;
+		};
+
+		port2 {
+			label = "poe_2";
+			mode = "semiauto";
+			max-power = <20196>;
+			auto-power;
+		};
+	};
+};

--- a/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-siemens-ipc520a.dts
+++ b/hardware/nvidia/platform/t19x/jakku/kernel-dts/tegra194-siemens-ipc520a.dts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024, Zededa Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+/dts-v1/;
+#include "common/tegra194-p3668-common.dtsi"
+#include "common/tegra194-p3509-0000-a00.dtsi"
+#include "common/tegra194-siemens-ipc520a.dtsi"
+
+/ {
+	model = "SIMATIC IPC520A";
+	nvidia,dtsfilename = __FILE__;
+	nvidia,dtbbuildtime = __DATE__, __TIME__;
+
+	compatible = "siemens,ipc520a", "nvidia,tegra194";
+
+	host1x@13e00000 {
+		dpaux@155F0000 {
+			status = "okay";
+		};
+	};
+
+	sdhci@3400000 {
+		status = "disabled";
+	};
+};
+
+&tegra_wdt {
+	status = "okay";
+};
+
+&head0 {
+	win-mask = <0x3f>;
+	nvidia,dc-connector = <&sor0>;
+	vdd-dp-pwr-supply = <&p3668_spmic_sd0>;
+	avdd-dp-pll-supply = <&p3668_spmic_sd1>;
+	vdd-edp-sec-mode-supply = <&battery_reg>;
+	vdd-dp-pad-supply = <&battery_reg>;
+};
+
+&head1 {
+	nvidia,dc-connector = <&sor1>;
+	avdd_hdmi-supply = <&p3668_spmic_sd0>; /* 1v0 */
+	avdd_hdmi_pll-supply = <&p3668_spmic_sd1>; /* 1v8 */
+	status = "disabled";
+	bootloader-status = "disabled";
+};
+
+&head2 {
+	bootloader-status = "disabled";
+};
+
+&head3 {
+	bootloader-status = "disabled";
+};
+
+&sor1 {
+	status = "disabled";
+};
+
+&sor1_hdmi_display {
+	status = "disabled";
+};
+
+&dpaux1 {
+	status = "disabled";
+};


### PR DESCRIPTION
This PR introduces the support for the Siemens IPC520A by performing the following:

- Port a workaround present in Siemens BSP's kernel, also introducing a module parameter so we can enable the workaround only when running on this particular device
- Add the corresponding device tree for the device (device's dtsi file was provided by Siemens)
