### PR TITLE
compile and install DTBS

### DIFF
--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -103,9 +103,9 @@ RUN make O=/kernel-out ${KERNEL_CONFIG}
 RUN --mount=type=cache,target=/root/.cache/ccache,id=kernel-ccache-${TARGETARCH} \
     ccache -z \
     && echo "Building kernel for ${TARGETARCH} with ARCH=${ARCH} and CROSS_COMPILE=${CROSS_COMPILE}" \
-    && make CC="${CROSS_COMPILE}gcc" O=/kernel-out LOCALVERSION="-${LOCALVERSION}" -j$(nproc) prepare Image modules \
+    && make CC="${CROSS_COMPILE}gcc" O=/kernel-out LOCALVERSION="-${LOCALVERSION}" -j$(nproc) prepare Image modules dtbs \
     && make CC="${CROSS_COMPILE}gcc" O=/kernel-out LOCALVERSION="-${LOCALVERSION}" -j$(nproc) modules_install INSTALL_MOD_STRIP=1 \
-        INSTALL_MOD_PATH=/tmp/kernel-modules #\
+        INSTALL_MOD_PATH=/tmp/kernel-modules \
     && make CC="${CROSS_COMPILE}gcc" O=/kernel-out -j$(nproc) \
         INSTALL_DTBS_PATH=/tmp/kernel-modules/boot/dtb dtbs_install && \
     ccache -s | tee -a /ccache-stats.txt


### PR DESCRIPTION
was accidentally commented out in 9c15946056c7ce929cdf2f694f5dd93ad6e93b75

Signed-off-by: Christoph Ostarek <christoph@zededa.com>
(cherry picked from commit 235a293632c7260c1920c55a167f2abc8f5058ae)