### PR TITLE
net/tg3: fix race condition in tg3_reset_task()

### DIFF
--- a/drivers/net/ethernet/broadcom/tg3.c
+++ b/drivers/net/ethernet/broadcom/tg3.c
@@ -6446,6 +6446,14 @@ static void tg3_dump_state(struct tg3 *tp)
 	int i;
 	u32 *regs;
 
+	/* If it is a PCI error, all registers will be 0xffff,
+	 * we don't dump them out, just report the error and return
+	 */
+	if (tp->pdev->error_state != pci_channel_io_normal) {
+		netdev_err(tp->dev, "PCI channel ERROR!\n");
+		return;
+	}
+
 	regs = kzalloc(TG3_REG_BLK_SIZE, GFP_ATOMIC);
 	if (!regs)
 		return;
@@ -11174,7 +11182,8 @@ static void tg3_reset_task(struct work_struct *work)
 	rtnl_lock();
 	tg3_full_lock(tp, 0);
 
-	if (tp->pcierr_recovery || !netif_running(tp->dev)) {
+	if (tp->pcierr_recovery || !netif_running(tp->dev) ||
+	    tp->pdev->error_state != pci_channel_io_normal) {
 		tg3_flag_clear(tp, RESET_TASK_PENDING);
 		tg3_full_unlock(tp);
 		rtnl_unlock();


### PR DESCRIPTION
## Description
This PR fixes the following crash of the tg3 ethernet driver:

```
[20947.029922] ------------[ cut here ]------------
[20947.071174] NETDEV WATCHDOG: keth0 (tg3): transmit queue 0 timed out
[20947.112071] WARNING: CPU: 6 PID: 0 at net/sched/sch_generic.c:525 dev_watchdog+0x174/0x1b0
[20947.153204] Modules linked in: dummy cfg80211 usbmouse usbkbd usbhid mhi_wwan_mbim mhi_wwan_ctrl mhi_pci_generic mhi wwan cdc_acm cdc_mbim cdc_ncm cdc_ether qmi_wwan usbnet mii cdc_wdm qcserial usb_wwan usbserial leds_gpio led_class gpio_pca953x regmap_i2c hwmon_vid nct6775_core zfs(PO) spl(O) bnxt_en hpwdt tg3 libphy i2c_i801 i2c_smbus tpm_crb
[20947.280353] CPU: 6 PID: 0 Comm: swapper/6 Kdump: loaded Tainted: P           O       6.1.38-linuxkit-b404564c5910 #1
[20947.324301] Hardware name: HPE ProLiant DL20 Gen11/ProLiant DL20 Gen11, BIOS 1.48 03/14/2024
[20947.368486] RIP: 0010:dev_watchdog+0x174/0x1b0
[20947.412250] Code: f4 36 5a 01 00 75 25 4c 89 e7 c6 05 e8 36 5a 01 01 e8 57 1e fb ff 89 e9 4c 89 e6 48 c7 c7 78 18 5d 83 48 89 c2 e8 81 80 6f ff <0f> 0b 4c 89 e7 e8 be fb ff ff 48 8b 83 88 fc ff ff 4c 89 e7 89 ee
[20947.501805] RSP: 0018:ffffb079802d8eb8 EFLAGS: 00010286
[20947.546103] RAX: 0000000000000000 RBX: ffff8bce011ca448 RCX: 0000000000000000
[20947.590538] RDX: 0000000000000104 RSI: ffffffff834ec65b RDI: 00000000ffffffff
[20947.634550] RBP: 0000000000000000 R08: 0000000000000000 R09: 0000000000aaaaaa
[20947.678068] R10: 0000000000000001 R11: 0000000000000001 R12: ffff8bce011ca000
[20947.721148] R13: ffff8bce011ca39c R14: 0000000000000005 R15: ffffffff82aaf963
[20947.763928] FS:  0000000000000000(0000) GS:ffff8bdd3fb80000(0000) knlGS:0000000000000000
[20947.807086] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[20947.850117] CR2: 00000052f6dff460 CR3: 000000013b1c6000 CR4: 0000000000752ea0
[20947.893393] PKRU: 55555554
[20947.935961] Call Trace:
[20947.977952]  <IRQ>
[20948.019427]  ? __warn+0x98/0x119
[20948.060428]  ? dev_watchdog+0x174/0x1b0
[20948.100953]  ? report_bug+0xee/0x164
[20948.140935]  ? handle_bug+0x42/0x74
[20948.179948]  ? exc_invalid_op+0x14/0x65
[20948.218573]  ? asm_exc_invalid_op+0x16/0x20
[20948.256755]  ? psched_ppscfg_precompute+0x44/0x44
[20948.294831]  ? dev_watchdog+0x174/0x1b0
[20948.332622]  ? dev_watchdog+0x174/0x1b0
[20948.369838]  ? psched_ppscfg_precompute+0x44/0x44
[20948.406996]  call_timer_fn+0x6c/0x10d
[20948.443830]  __run_timers+0x146/0x188
[20948.479664]  ? net_rx_action+0x165/0x264
[20948.514558]  run_timer_softirq+0x2b/0x43
[20948.548667]  __do_softirq+0x126/0x284
[20948.582834]  __irq_exit_rcu+0x5e/0xb8
[20948.615969]  common_interrupt+0x9a/0xc0
[20948.648014]  </IRQ>
[20948.678783]  <TASK>
[20948.708333]  asm_common_interrupt+0x22/0x40
[20948.737155] RIP: 0010:poll_idle+0x6c/0xc2
[20948.765792] Code: 65 7b cd ff 85 c0 75 3e 4c 89 ef 48 89 de e8 d2 61 cd ff 49 89 c5 41 be c9 00 00 00 48 89 ef e8 45 7b cd ff 85 c0 75 1e f3 90 <41> ff ce 75 ed 65 8b 3d ff 54 30 7d e8 b5 b6 4d ff 4c 29 f8 4c 39
[20948.824646] RSP: 0018:ffffb0798017fe60 EFLAGS: 00000246
[20948.853784] RAX: 0000000000000000 RBX: ffffd0797f799400 RCX: 000000000000001f
[20948.882868] RDX: 0000000000000000 RSI: ffffffe49f686d7a RDI: ffff8bce00adc040
[20948.911710] RBP: ffff8bce00adc040 R08: 0000130d1c46df9f R09: 071c71c71c71c71c
[20948.940337] R10: 0000000000000020 R11: 0000000000000000 R12: 0000000000000000
[20948.968306] R13: 000000000005d048 R14: 0000000000000032 R15: 0000130d1c466c38
[20948.995120]  cpuidle_enter_state+0xc9/0x20c
[20949.020942]  cpuidle_enter+0x2a/0x3a
[20949.045660]  do_idle+0x158/0x1cb
[20949.069380]  cpu_startup_entry+0x1d/0x1f
[20949.092657]  start_secondary+0x103/0x103
[20949.115310]  secondary_startup_64_no_verify+0xcd/0xdb
[20949.137591]  </TASK>
[20949.159069] ---[ end trace 0000000000000000 ]---
```

This issues is fixed by porting the following commit from newer kernel versions:

```
commit e94f65e20cf2c8237b68834f8f74eb838ef00a67
Author: Thinh Tran <thinhtr@linux.vnet.ibm.com>
Date:   Thu Nov 30 18:19:11 2023 -0600

    net/tg3: fix race condition in tg3_reset_task()

When an EEH error is encountered by a PCI adapter, the EEH driver modifies the PCI channel's state as shown below:

   enum {
      /* I/O channel is in normal state */
      pci_channel_io_normal = (__force pci_channel_state_t) 1,

      /* I/O to channel is blocked */
      pci_channel_io_frozen = (__force pci_channel_state_t) 2,

      /* PCI card is dead */
      pci_channel_io_perm_failure = (__force pci_channel_state_t) 3,
   };

If the same EEH error then causes the tg3 driver's transmit timeout logic to execute, the tg3_tx_timeout() function schedules a reset task via tg3_reset_task_schedule(), which may cause a race condition between the tg3 and EEH driver as both attempt to recover the HW via a reset action.

EEH driver gets error event
--> eeh_set_channel_state()
    and set device to one of
    error state above           scheduler: tg3_reset_task() get
                                returned error from tg3_init_hw()
                             --> dev_close() shuts down the interface
tg3_io_slot_reset() and
tg3_io_resume() fail to
reset/resume the device

To resolve this issue, we avoid the race condition by checking the PCI channel state in the tg3_reset_task() function and skip the tg3 driver initiated reset when the PCI channel is not in the normal state.  (The driver has no access to tg3 device registers at this point and cannot even complete the reset task successfully without external assistance.) We'll leave the reset procedure to be managed by the EEH driver which calls the tg3_io_error_detected(), tg3_io_slot_reset() and tg3_io_resume() functions as appropriate.

Adding the same checking in tg3_dump_state() to avoid dumping all device registers when the PCI channel is not in the normal state.


Tested-by: Venkata Sai Duggi <venkata.sai.duggi@ibm.com>
Reviewed-by: David Christensen <drc@linux.vnet.ibm.com>
Reviewed-by: Michael Chan <michael.chan@broadcom.com>
Link: https://lore.kernel.org/r/20231201001911.656-1-thinhtr@linux.vnet.ibm.com
```

## Notes

This commit is already available on 6.1.106 and 6.1.112, so no need to port.