### PR TITLE
arm: dts: Fix Onlogic FR201 LEDs

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4-fr201.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-fr201.dts
@@ -2,11 +2,20 @@
 
 /* Nodes for OnLogic FR201 device */
 
-/* Power LED */
-&leds {
-	led-pwr {
-		default-state = "off";
-		linux,default-trigger = "none";
+/* LEDs */
+/ {
+	leds {
+		act_led: led-act {
+			default-state = "off";
+			linux,default-trigger = "none";
+			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
+		};
+
+		pwr_led: led-pwr {
+			default-state = "off";
+			linux,default-trigger = "default-on";
+			gpios = <&expgpio 2 GPIO_ACTIVE_HIGH>;
+		};
 	};
 };
 


### PR DESCRIPTION
Fix configuration for PWR and ACT LEDs on Onlogic FR201 device:

* PWR should be turned ON by default and the associated GPIO high active
* ACT LED shouldn't have any default trigger mode