### PR TITLE
[eve-kernel-arm64-v6.1.112-generic]: arm64: dts: Disable spidev1 in favor of TPM also for FR201 device

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4-fr201.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-fr201.dts
@@ -53,6 +53,9 @@
 	brcm,pins = <18 19 20 21>;
 	brcm,function = <0>;
 };
+&spidev1 {
+	status = "disabled";
+};
 
 /* RTC */
 &i2c0if {


### PR DESCRIPTION
The same fix provided by commit 34056de6ff5bf7926cbf5ec8f2ab99c3e2b43f26 must be applied for the FR201 device, so CS pin of SPI1 can be used by the TPM driver at SPI6.