### PR TITLE
Use only XL runners for building the kernel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
             fail-fast: false
             max-parallel: 2
 
-        runs-on: self-hosted
+        runs-on: [runner-xl, X64, Linux]
 
         if: >
             github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
- kernel requires a lot of cores for fatst build. Use only suitable runners for it

@uncleDecart is creating those runners so we'll wait with the merge till his approval