### PR TITLE
Login to Dockerhub for pulling images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Login to Docker Hub
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve-kernel'
+        uses: docker/login-action@v3
+        with:
+            username: ${{ secrets.DOCKERHUB_PULL_USER }}
+            password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+
       - name: Build eve-kernel-arm64
         run: |
           make -f Makefile.eve BRANCH?=${GITHUB_REF##*/} kernel-gcc


### PR DESCRIPTION
On 01.04.2025 Dockerhub reduced a number of unauthenticated pulls so let's login to unlimited account to avoid build errors on CI