### PR TITLE
GHA: create separate concurancy groups

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
               with:
                   ref: ${{ steps.set-ref.outputs.ref_to_use }}
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
-                  fetch-depth: 0
+                  fetch-depth: 1
 
             - name: Login to Docker Hub
               if: ${{ github.event.repository.full_name }}== 'lf-edge/eve-kernel'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,10 @@ on:
             ref:
                 description: "Branch or tag to build"
                 required: false
-    pull_request_target: {}
+    pull_request_target:
+        branches:
+            - "eve-kernel-next"
+            - "eve-kernel-*-v[0-9]+.[0-9]+.[0-9]+-*"
     push:
         branches:
             - "eve-kernel-amd64-v6.1.112-generic"
@@ -15,7 +18,11 @@ env:
     BASE_REF: "eve-kernel-amd64-v6.1.112-generic" # no refs/heads/ prefix
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.event_name }}-${{
+        github.event.pull_request.number ||
+        (github.event_name == 'push' && github.ref) ||
+        github.ref_name
+        }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
We need to
    1. Cancel current build if PR was pushed again
    2. But do not cancel builds on target branch if the build is still going
    but new PR is pushed

Also limit checkout depth to speedup build