### PR TITLE
kbuild: Use objtree for module signing key path

### DIFF
--- a/scripts/Makefile.modinst
+++ b/scripts/Makefile.modinst
@@ -100,7 +100,7 @@ endif
 # Don't stop modules_install even if we can't sign external modules.
 #
 ifeq ($(filter pkcs11:%, $(CONFIG_MODULE_SIG_KEY)),)
-sig-key := $(if $(wildcard $(CONFIG_MODULE_SIG_KEY)),,$(srctree)/)$(CONFIG_MODULE_SIG_KEY)
+sig-key := $(if $(wildcard $(CONFIG_MODULE_SIG_KEY)),,$(objtree)/)$(CONFIG_MODULE_SIG_KEY)
 else
 sig-key := $(CONFIG_MODULE_SIG_KEY)
 endif


### PR DESCRIPTION
## Upstreaming status
The patch is submitted upstream https://marc.info/?l=linux-kbuild&m=176054596327578&w=2

**UPDATE:** patch was applied to `kbuild-next`

## Impact

Out-of-tree modules e.g. Hailo and ZFS are not signed but the build is not generation error so it was missed

## Description
When building out-of-tree modules with CONFIG_MODULE_SIG_FORCE=y, module signing fails because the private key path uses $(srctree) while the public key path uses $(objtree). Since signing keys are generated in the build directory during kernel compilation, both paths should use $(objtree) for consistency.

This causes SSL errors like:
  SSL error:02001002:system library:fopen:No such file or directory
  sign-file: /kernel-src/certs/signing_key.pem

The issue occurs because:
- sig-key uses: $(srctree)/certs/signing_key.pem (source tree)
- cmd_sign uses: $(objtree)/certs/signing_key.x509 (build tree)

But both keys are generated in $(objtree) during the build.

This complements commit 25ff08aa43e37 ('kbuild: Fix signing issue for external modules') which fixed the scripts path and public key path, but missed the private key path inconsistency.

Fixes out-of-tree module signing for configurations with separate source and build directories (e.g., O=/kernel-out).