### PR TITLE
Disable PR workflow for JP branches

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,6 +5,8 @@ on: # yamllint disable-line rule:truthy
         branches:
             - "gha-test-rebase"
             - "eve-kernel-*"
+            - "!eve-kernel-arm64-v5.15.136-nvidia-jp6"
+            - "!eve-kernel-arm64-v5.10.192-nvidia-jp5"
         paths-ignore:
             - ".github/**"
 


### PR DESCRIPTION
pull_request_target workflow is taken from a default branch however it must not be run for 
- `eve-kernel-arm64-v5.15.136-nvidia-jp6` 
- `eve-kernel-arm64-v5.10.192-nvidia-jp5` 
- So disable it for these branches