### PR TITLE
Add cleanup steps to CI workflows and Makefile

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -48,3 +48,10 @@ jobs:
                     KERNEL_CONFIG_FLAVOR=${{ matrix.flavor }} \
                     BRANCH=$SAFE_BRANCH \
                     kernel-gcc
+
+            - name: Clean
+              if: always()
+              run: |
+                make -f Makefile.eve clean
+                docker system prune -af
+                docker volume prune -af

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,3 +52,10 @@ jobs:
                     KERNEL_CONFIG_FLAVOR=${{ matrix.flavor }} \
                     BRANCH=${{ github.ref_name }} \
                     push-gcc
+
+            - name: Clean
+              if: always()
+              run: |
+                make -f Makefile.eve clean
+                docker system prune -af
+                docker volume prune -af

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -190,4 +190,6 @@ push-image-%:
 	    $(IMAGE_TAG_NO_FLAVOR)-$*,)
 .PHONY: clean
 clean:
-	echo "Cleaning"
+	$(LK) cache clean
+	rm -f $(LK)
+	docker kill $(BUILD_KIT_BUILDER)


### PR DESCRIPTION
To prevent GH runners from filling up we clean up all artifacts created during the build process.