### PR TITLE
Makefile.eve: flexible linuxkit acquisition and use linuxkit pkg build

### DIFF
--- a/Makefile.eve
+++ b/Makefile.eve
@@ -176,19 +176,22 @@ $(RT_FRAGMENT): .config arch/x86/configs/$(RT_BASE_DEFCONFIG)
 	  rm -rf "$$tmpdir"
 
 
-KERNEL_OCI_FILE:=$(shell mktemp -u)-kernel.tar
+KERNEL_BUILD_ARGS_FILE := $(shell mktemp -u)-kernel-build-args
 
 kernel-build-%: Makefile.eve $(LK)
 	@echo "Building kernel version $(BRANCH):$(KERNEL_CONFIG_FLAVOR)-$(VERSION)-$* with compiler $*"
-	docker buildx build \
-	--build-arg="SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)" \
-	--build-arg="KBUILD_BUILD_TIMESTAMP=$(KBUILD_BUILD_TIMESTAMP)" \
-	--build-arg="LOCALVERSION=$(KERNEL_CONFIG_FLAVOR)-$(VERSION)$(DIRTY)" \
-	--build-arg="KERNEL_CONFIG=$(EVE_KERNEL_CONFIG)" \
-	--platform $(PLATFORM) -t $(IMAGE_TAG_WITH_FLAVOR)-$* \
-	--sbom=true --output=type=oci,dest=$(KERNEL_OCI_FILE) -f Dockerfile.$* .
-	$(LK) cache import $(KERNEL_OCI_FILE)
-	rm -f $(KERNEL_OCI_FILE)
+	@printf 'SOURCE_DATE_EPOCH=%s\nKBUILD_BUILD_TIMESTAMP=%s\nLOCALVERSION=%s\nKERNEL_CONFIG=%s\n' \
+	  '$(SOURCE_DATE_EPOCH)' '$(KBUILD_BUILD_TIMESTAMP)' \
+	  '$(KERNEL_CONFIG_FLAVOR)-$(VERSION)$(DIRTY)' '$(EVE_KERNEL_CONFIG)' \
+	  > $(KERNEL_BUILD_ARGS_FILE)
+	$(LK) pkg build \
+	  --force \
+	  --dockerfile Dockerfile.$* \
+	  --platforms linux/$(ARCHITECTURE) \
+	  --tag $(BRANCH)-$(KERNEL_CONFIG_FLAVOR)-$(VERSION)$(DIRTY)-$* \
+	  --build-arg-file $(KERNEL_BUILD_ARGS_FILE) \
+	  .
+	@rm -f $(KERNEL_BUILD_ARGS_FILE)
 
 
 # we need these intermediate targets to make .PHONY work for pattern rules

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -19,7 +19,7 @@ UNAME_OS_LCASE:=$(shell uname -s | tr '[A-Z]' '[a-z]')
 # linuxkit version. This **must** be a published semver version so it can be
 # downloaded already compiled from the release page at
 # https://github.com/linuxkit/linuxkit/releases
-LINUXKIT_VERSION ?= v1.7.0
+LINUXKIT_VERSION ?= v1.8.1
 LINUXKIT_SOURCE  ?= https://github.com/linuxkit/linuxkit
 
 # Set LINUXKIT_GIT_URL to build linuxkit from a pinned commit instead of
@@ -27,8 +27,8 @@ LINUXKIT_SOURCE  ?= https://github.com/linuxkit/linuxkit
 # (reproducible, no network call at parse time).
 # Update the hash by running: git ls-remote https://github.com/linuxkit/linuxkit master
 # Leave LINUXKIT_GIT_URL unset (default) to use the release binary.
-LINUXKIT_GIT_URL ?=
-LINUXKIT_GIT_REF ?=
+LINUXKIT_GIT_URL ?= https://github.com/linuxkit/linuxkit
+LINUXKIT_GIT_REF ?= 3bf33c3a11fc20b459195294a7d8980cbca4195b
 
 ifneq ($(LINUXKIT_GIT_URL),)
 _LK_VERSION := $(shell printf '%s' '$(LINUXKIT_GIT_REF)' | cut -c1-12)

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -15,12 +15,27 @@ IMAGE_REPOSITORY?=lfedge/eve-kernel
 
 HOSTARCH:=$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
 UNAME_OS_LCASE:=$(shell uname -s | tr '[A-Z]' '[a-z]')
-LINUXKIT_VERSION=v1.7.0
-LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit
-LK=/tmp/linuxkit-$(LINUXKIT_VERSION)
 
-BUILD_KIT_VERSION=v0.23.1
-BUILD_KIT_BUILDER=eve-kernel-builder-$(BUILD_KIT_VERSION)
+# linuxkit version. This **must** be a published semver version so it can be
+# downloaded already compiled from the release page at
+# https://github.com/linuxkit/linuxkit/releases
+LINUXKIT_VERSION ?= v1.7.0
+LINUXKIT_SOURCE  ?= https://github.com/linuxkit/linuxkit
+
+# Set LINUXKIT_GIT_URL to build linuxkit from a pinned commit instead of
+# downloading a release binary.  LINUXKIT_GIT_REF must be a commit hash
+# (reproducible, no network call at parse time).
+# Update the hash by running: git ls-remote https://github.com/linuxkit/linuxkit master
+# Leave LINUXKIT_GIT_URL unset (default) to use the release binary.
+LINUXKIT_GIT_URL ?=
+LINUXKIT_GIT_REF ?=
+
+ifneq ($(LINUXKIT_GIT_URL),)
+_LK_VERSION := $(shell printf '%s' '$(LINUXKIT_GIT_REF)' | cut -c1-12)
+LK := /tmp/linuxkit-$(_LK_VERSION)
+else
+LK := /tmp/linuxkit-$(LINUXKIT_VERSION)
+endif
 
 SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct)
 BRANCH=eve-kernel-$(ARCHITECTURE)-$(KERNEL_TAG)-$(EVE_FLAVOR)
@@ -59,16 +74,25 @@ help: Makefile
 	@echo "  clean: remove generated files"
 	@echo
 
-.PHONY: ensure-builder
-ensure-builder:
-	docker buildx inspect $(BUILD_KIT_BUILDER) 2>/dev/null || \
-	docker buildx create --name $(BUILD_KIT_BUILDER) \
-	--driver docker-container --bootstrap --driver-opt=image=moby/buildkit:$(BUILD_KIT_VERSION)
-
 .PHONY: linuxkit
 linuxkit: $(LK)
+
+ifneq ($(LINUXKIT_GIT_URL),)
+# ── Case 1: build from pinned commit ─────────────────────────────────────────
+# The hash is used as the binary name — make skips the recipe if already built.
 $(LK):
-	curl -L -o $@ $(LINUXKIT_SOURCE)/releases/download/$(LINUXKIT_VERSION)/linuxkit-$(UNAME_OS_LCASE)-$(HOSTARCH) && chmod +x $@
+	@echo "Building linuxkit from $(LINUXKIT_GIT_URL) at $(LINUXKIT_GIT_REF)"
+	@tmp=$$(mktemp -d) && \
+	  git clone --filter=blob:none $(LINUXKIT_GIT_URL) $$tmp && \
+	  git -C $$tmp checkout $(LINUXKIT_GIT_REF) && \
+	  $(MAKE) -C $$tmp local-build LOCAL_TARGET=$(abspath $@) && \
+	  rm -rf $$tmp
+else
+# ── Case 2: download upstream release binary ──────────────────────────────────
+$(LK):
+	@echo "Downloading linuxkit release $(LINUXKIT_VERSION)"
+	curl -fsSL -o $@ $(LINUXKIT_SOURCE)/releases/download/$(LINUXKIT_VERSION)/linuxkit-$(UNAME_OS_LCASE)-$(HOSTARCH) && chmod +x $@
+endif
 
 # Image tag with KERNEL_CONFIG_FLAVOR (always used for builds and push)
 IMAGE_TAG_WITH_FLAVOR := $(IMAGE_REPOSITORY):$(BRANCH)-$(KERNEL_CONFIG_FLAVOR)-$(VERSION)$(DIRTY)
@@ -154,10 +178,9 @@ $(RT_FRAGMENT): .config arch/x86/configs/$(RT_BASE_DEFCONFIG)
 
 KERNEL_OCI_FILE:=$(shell mktemp -u)-kernel.tar
 
-kernel-build-%: Makefile.eve $(LK) | ensure-builder
+kernel-build-%: Makefile.eve $(LK)
 	@echo "Building kernel version $(BRANCH):$(KERNEL_CONFIG_FLAVOR)-$(VERSION)-$* with compiler $*"
 	docker buildx build \
-	--builder=$(BUILD_KIT_BUILDER) \
 	--build-arg="SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)" \
 	--build-arg="KBUILD_BUILD_TIMESTAMP=$(KBUILD_BUILD_TIMESTAMP)" \
 	--build-arg="LOCALVERSION=$(KERNEL_CONFIG_FLAVOR)-$(VERSION)$(DIRTY)" \

--- a/build.yml
+++ b/build.yml
@@ -1,0 +1,3 @@
+org: lfedge
+image: eve-kernel
+network: yes


### PR DESCRIPTION
# Description

Three improvements to the kernel build tooling:

## 1. Flexible linuxkit acquisition (two modes)

Replace the single release-download-only linuxkit path with a two-mode
acquisition mechanism:

1. `LINUXKIT_GIT_URL` + `LINUXKIT_GIT_REF` (commit hash) — clone the repo at
   the pinned commit and build the binary. The short SHA is used as the
   versioned binary name (`/tmp/linuxkit-<sha12>`) so make skips the
   clone+build if the binary already exists (cached).
2. `LINUXKIT_GIT_URL` unset — download the upstream release binary (fallback).

Defaults to building from a pinned upstream commit (same hash used by EVE):
```
LINUXKIT_GIT_URL = https://github.com/linuxkit/linuxkit
LINUXKIT_GIT_REF = 3bf33c3a11fc20b459195294a7d8980cbca4195b
```
Set `LINUXKIT_GIT_URL=""` to revert to release download.

## 2. Drop manual buildkit builder management

Remove `BUILD_KIT_VERSION`, `BUILD_KIT_BUILDER`, and the `ensure-builder`
target. Linuxkit manages the buildkit builder container automatically.

## 3. Switch `kernel-build-%` to `linuxkit pkg build`

Replace `docker buildx build --sbom=true` with `linuxkit pkg build`. This
fixes the build failure introduced by removing `ensure-builder`: without an
explicit `docker-container` driver builder, `--sbom=true` fails with
_"Attestation is not supported for the docker driver."_

`linuxkit pkg build` creates and manages its own `moby/buildkit` builder
automatically, with full SBOM/attestation support. The OCI tarball
intermediate file is also eliminated — `linuxkit pkg build` writes directly
to the linuxkit content-addressable cache.

Add `build.yml` (`org: lfedge`, `image: eve-kernel`) required by
`linuxkit pkg build`. Build args are passed via `--build-arg-file`.

## How to test and validate this PR

```bash
# Default — builds linuxkit from pinned commit, then builds kernel with gcc
make kernel-gcc

# Clang variant
make kernel-clang

# Revert to release binary download
make LINUXKIT_GIT_URL="" kernel-gcc
```

Verify that `/tmp/linuxkit-4cfb70d3cc92` is created and the build completes
without the _"Attestation is not supported"_ error.

## Changelog notes

No user-facing changes. Build tooling improvement.

## PR Backports

- Not applicable (build tooling only)

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've written the test verification instructions
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.