### PR TITLE
GHA: targeted cleanup — preserve BuildKit ccache across runs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,7 +1,7 @@
 name: PR Build
 
 on: # yamllint disable-line rule:truthy
-    pull_request_target:
+    pull_request:
         branches:
             - "gha-test-rebase"
             - "eve-kernel-*"
@@ -36,12 +36,6 @@ jobs:
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
                   fetch-depth: 1
 
-            - name: Login to Docker Hub
-              uses: docker/login-action@v3
-              with:
-                  username: ${{ secrets.DOCKERHUB_PULL_USER }}
-                  password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-
             - name: Build kernel flavor ${{ matrix.flavor }}
               run: |
                   make -f Makefile.eve \
@@ -52,6 +46,17 @@ jobs:
             - name: Clean
               if: always()
               run: |
-                make -f Makefile.eve clean
-                docker system prune -af
-                docker volume prune -af
+                  make -f Makefile.eve \
+                    KERNEL_CONFIG_FLAVOR=${{ matrix.flavor }} \
+                    BRANCH=$SAFE_BRANCH \
+                    clean-gcc
+                  if docker ps -q -f name=linuxkit-builder | grep -q .; then
+                      echo "=== BuildKit disk usage before prune ==="
+                      docker exec linuxkit-builder buildctl du | tail -n 2
+                      echo "=== Reclaiming ==="
+                      docker exec linuxkit-builder buildctl prune --keep-storage "${BUILDKIT_KEEP_STORAGE_MB:-32000}" | tail -n 1
+                      echo "=== BuildKit disk usage after prune ==="
+                      docker exec linuxkit-builder buildctl du | tail -n 2
+                  else
+                      echo "linuxkit-builder container not running; skipping BuildKit cleanup."
+                  fi

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -30,7 +30,7 @@ jobs:
                   SAFE_BRANCH="${BRANCH_NAME//\//-}"
                   echo "SAFE_BRANCH=$SAFE_BRANCH" >> $GITHUB_ENV
             - name: Checkout PR code
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
                   repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,13 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ github.ref }}
                   fetch-depth: 1
 
             - name: Login to Docker Hub (pull)
-              uses: docker/login-action@v3
+              uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
               with:
                   username: ${{ secrets.DOCKERHUB_PULL_USER }}
                   password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
                     kernel-gcc
 
             - name: Login to Docker Hub (push)
-              uses: docker/login-action@v3
+              uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
               with:
                   username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
                   password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,17 @@ jobs:
             - name: Clean
               if: always()
               run: |
-                make -f Makefile.eve clean
-                docker system prune -af
-                docker volume prune -af
+                  make -f Makefile.eve \
+                    KERNEL_CONFIG_FLAVOR=${{ matrix.flavor }} \
+                    BRANCH=${{ github.ref_name }} \
+                    clean-gcc
+                  if docker ps -q -f name=linuxkit-builder | grep -q .; then
+                      echo "=== BuildKit disk usage before prune ==="
+                      docker exec linuxkit-builder buildctl du | tail -n 2
+                      echo "=== Reclaiming ==="
+                      docker exec linuxkit-builder buildctl prune --keep-storage "${BUILDKIT_KEEP_STORAGE_MB:-32000}" | tail -n 1
+                      echo "=== BuildKit disk usage after prune ==="
+                      docker exec linuxkit-builder buildctl du | tail -n 2
+                  else
+                      echo "linuxkit-builder container not running; skipping BuildKit cleanup."
+                  fi

--- a/Makefile.eve
+++ b/Makefile.eve
@@ -202,7 +202,10 @@ docker-tag-clang: docker-tag-generate-clang
 push-gcc: push-image-gcc
 push-clang: push-image-clang
 
-.PHONY: kernel-gcc kernel-clang docker-tag-gcc docker-tag-clang push-gcc push-clang
+clean-gcc: clean-image-gcc
+clean-clang: clean-image-clang
+
+.PHONY: kernel-gcc kernel-clang docker-tag-gcc docker-tag-clang push-gcc push-clang clean-gcc clean-clang
 
 docker-tag-generate-%:
 	@echo "docker.io/$(IMAGE_TAG_WITH_FLAVOR)-$*"
@@ -214,6 +217,10 @@ push-image-%:
 	  $(LK) pkg remote-tag \
 	    $(IMAGE_TAG_WITH_FLAVOR)-$* \
 	    $(IMAGE_TAG_NO_FLAVOR)-$*,)
+clean-image-%:
+	$(LK) cache rm $(IMAGE_TAG_WITH_FLAVOR)-$* 2>/dev/null || true
+	docker rmi $(IMAGE_TAG_WITH_FLAVOR)-$* 2>/dev/null || true
+
 .PHONY: clean
 clean:
 	$(LK) cache clean


### PR DESCRIPTION
## Summary

Finally move back to `on: pull_request` and remove docker login. Also rework broken clean-up target and properly control disk consumption

Replace the nuclear `docker system prune -af` / `docker volume prune -af` in CI cleanup with targeted removal, preserving BuildKit ccache across runs on self-hosted runners.

## Changes

### Commit 1: Pin actions to commit SHAs and bump to latest versions
- `actions/checkout`: v4 → v6.0.2 (pinned to SHA)
- `docker/login-action`: v3 → v4.0.0 (pinned to SHA)
- Fixes Node.js 20 deprecation warning

### Commit 2: Targeted cleanup — preserve BuildKit ccache
- Replace `docker system prune -af` and `docker volume prune -af` with targeted removal of only the image we just built
- Add `clean-gcc`/`clean-clang` Makefile targets that remove specific image from both linuxkit cache and docker
- Add BuildKit cache pruning with configurable quota via `BUILDKIT_KEEP_STORAGE_MB` env var (defaults to 32000 MB)
- Print BuildKit disk usage before/after pruning for diagnostics
- Use `buildctl` inside `linuxkit-builder` container for cache management
- Switch pr-build.yml from `pull_request_target` to `pull_request`
- Remove unnecessary Docker Hub login from PR builds

## Testing

Tested via PR #205 against `gha-test-rebase` branch on production runners.