### PR TITLE
Dockerfile.gcc: bump ZFS to 2.3.6

### DIFF
--- a/Dockerfile.gcc
+++ b/Dockerfile.gcc
@@ -134,7 +134,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=kernel-ccache-${TARGETARCH}
         INSTALL_MOD_PATH=/tmp/kernel-modules \
     && ccache -s | tee -a /ccache-stats.txt
 
-ADD https://github.com/openzfs/zfs.git#zfs-2.3.3 /tmp/zfs
+ADD https://github.com/openzfs/zfs.git#zfs-2.3.6 /tmp/zfs
 WORKDIR /tmp/zfs
 
 RUN --mount=type=cache,target=/root/.cache/ccache,id=zfs-ccache-${TARGETARCH} \


### PR DESCRIPTION
## Description

Bump ZFS from 2.3.3 to 2.3.6. ZFS 2.3.6 adds support for kernels up to 6.19.

## How to test and validate this PR

Build the kernel image and verify ZFS module loads correctly.

## Changelog notes

Bumped ZFS to 2.3.6 for kernel 6.12 (amd64 generic).
