### PR TITLE
GHA: targeted cleanup — preserve BuildKit ccache across runs

### DIFF
--- a/Makefile.eve
+++ b/Makefile.eve
@@ -84,7 +84,10 @@ docker-tag-clang: docker-tag-generate-clang
 push-gcc: push-image-gcc
 push-clang: push-image-clang
 
-.PHONY: kernel-gcc kernel-clang docker-tag-gcc docker-tag-clang push-gcc push-clang
+clean-gcc: clean-image-gcc
+clean-clang: clean-image-clang
+
+.PHONY: kernel-gcc kernel-clang docker-tag-gcc docker-tag-clang push-gcc push-clang clean-gcc clean-clang
 
 docker-tag-generate-%:
 	@echo "docker.io/$(IMAGE_REPOSITORY):$(BRANCH)-$(VERSION)$(DIRTY)-$*"
@@ -93,6 +96,10 @@ push-image-%:
 	$(if $(DIRTY), $(error "Not pushing since the repo is dirty"))
 	$(LK) cache push $(IMAGE_REPOSITORY):$(BRANCH)-$(VERSION)-$*
 
+clean-image-%:
+	$(LK) cache rm $(IMAGE_REPOSITORY):$(BRANCH)-$(VERSION)$(DIRTY)-$* 2>/dev/null || true
+	docker rmi $(IMAGE_REPOSITORY):$(BRANCH)-$(VERSION)$(DIRTY)-$* 2>/dev/null || true
+
 .PHONY: clean
 clean:
-	echo "Cleaning"
+	$(LK) cache clean


### PR DESCRIPTION
Add `make clean` target. Cherry picked missing commit 04d922430698ff01ed1c746418743514e2cfdf50

This fixes the build/publish workflow.